### PR TITLE
ReactDOM.render deprecated, update Element README

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -38,9 +38,10 @@ Let's render a customized greeting into an empty element:
 		);
 	}
 
-	wp.element.render(
-		wp.element.createElement( Greeting, { toWhom: 'World' } ),
-		document.getElementById( 'greeting' )
+	wp.element.createRoot(document.getElementById("greeting"))
+		.render(
+			wp.element.createElement( Greeting, { toWhom: 'World' } )
+		)
 	);
 </script>
 ```

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -38,7 +38,7 @@ Let's render a customized greeting into an empty element:
 		);
 	}
 
-	wp.element.createRoot(document.getElementById("greeting"))
+	wp.element.createRoot(document.getElementById( 'greeting' ))
 		.render(
 			wp.element.createElement( Greeting, { toWhom: 'World' } )
 		)


### PR DESCRIPTION
 The Element package doc README provides this usage example:  

  ```
       wp.element.render(
           wp.element.createElement( Greeting, { toWhom: 'World' } ),
           document.getElementById( 'greeting' )
      );
  ```
  
  This results in warning:
  
  >  ReactDOM.render is no longer supported in React 18.
  >  Use createRoot instead. Until you switch to the new API,
  >  your app will behave as if it's running React 17.
  >  Learn more: https://reactjs.org/link/switch-to-createroot
  
  The new equivalent does not generate a warning:
  
  ```
      wp.element.createRoot(document.getElementById("greeting"))
          .render(
        wp.element.createElement( Greeting, { toWhom: 'World' } )
          )
      );
  ```